### PR TITLE
refactor: rename bot configuration keys in package-info.json

### DIFF
--- a/packages/slack-web-tiny/README.md
+++ b/packages/slack-web-tiny/README.md
@@ -88,6 +88,8 @@ const message = await slackSDK.sendMessage({
       accessory: blocks.button('Click Me', 'button_click_action'),
     }),
   ],
+  username: 'Bot/Author Name', // process.env.SLACK_AUTHOR_NAME
+  icon_url: 'https://image.bot.com', // process.env.SLACK_ICON_URL
 });
 ```
 

--- a/packages/slack-web-tiny/package-info.json
+++ b/packages/slack-web-tiny/package-info.json
@@ -31,7 +31,7 @@
       "internalKeys": [],
       "botConfig": [
         {
-          "key": "AUTHOR_NAME",
+          "key": "SLACK_AUTHOR_NAME",
           "displayName": "Bot Name",
           "description": "Name that will appear as the message sender",
           "ui": {
@@ -41,7 +41,7 @@
           }
         },
         {
-          "key": "ICON_URL",
+          "key": "SLACK_ICON_URL",
           "displayName": "Bot Icon",
           "description": "Icon that will appear as the bot's avatar",
           "ui": {


### PR DESCRIPTION
- Updated `AUTHOR_NAME` to `SLACK_AUTHOR_NAME` and `ICON_URL` to `SLACK_ICON_URL` for better clarity and consistency in bot configuration.
- Added example usage in README.md to reflect the new environment variable names for bot customization.