### PR TITLE
feat: extend Instructions schema to support external links

### DIFF
--- a/scripts/src/types.ts
+++ b/scripts/src/types.ts
@@ -57,7 +57,7 @@ export const PackageReadmeMap = z
   );
 
 export const Instructions = z.object({
-  type: z.enum(['video', 'image']),
+  type: z.enum(['video', 'image', 'externalLink']),
   url: z.string().url(),
   placement: z.enum(['onCopy', 'onHowToGet']).optional(),
 });


### PR DESCRIPTION
- Updated the Instructions schema in types.ts to include 'externalLink' as a valid type, enhancing the flexibility for media handling.