### PR TITLE
chore: modify release workflow to build with specific options

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,9 @@ jobs:
           node-version: 20
 
       - name: Install Dependencies
-        run: npm i
+        run: |
+          npm i --ignore-scripts
+          npm run build --workspace=* --ignore microfox-scripts
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets


### PR DESCRIPTION
- Updated the release workflow in release.yml to run npm install with the --ignore-scripts flag and build all workspaces while ignoring microfox-scripts, ensuring a cleaner release process.