### PR TITLE
Fix Linkedin Share Response

### DIFF
--- a/packages-list.json
+++ b/packages-list.json
@@ -79,5 +79,5 @@
     "packages/rest-sdk"
   ],
   "total": 69,
-  "generatedAt": "2025-04-30T07:19:18.815Z"
+  "generatedAt": "2025-04-30T10:36:52.953Z"
 }

--- a/packages/linkedin-share/src/schemas/share.ts
+++ b/packages/linkedin-share/src/schemas/share.ts
@@ -66,7 +66,7 @@ export const shareContentSchema = z.object({
 });
 
 export const shareResponseSchema = z.object({
-  sub: z.string(),
+  id: z.string(),
   activity: z.string(),
   created: z.object({
     actor: z.string(),

--- a/packages/linkedin-share/src/schemas/share.ts
+++ b/packages/linkedin-share/src/schemas/share.ts
@@ -65,18 +65,23 @@ export const shareContentSchema = z.object({
   }),
 });
 
+/**
+ * 
+ * We only get the 'id' from the response @subhakar @vishwajeet
+ */
+
 export const shareResponseSchema = z.object({
   id: z.string(),
-  activity: z.string(),
-  created: z.object({
-    actor: z.string(),
-    time: z.number(),
-  }),
-  lastModified: z.object({
-    actor: z.string(),
-    time: z.number(),
-  }),
-  lifecycleState: z.string(),
+  // activity: z.string(),
+  // created: z.object({
+  //   actor: z.string(),
+  //   time: z.number(),
+  // }),
+  // lastModified: z.object({
+  //   actor: z.string(),
+  //   time: z.number(),
+  // }),
+  // lifecycleState: z.string(),
 });
 
 // Export inferred types

--- a/packages/linkedin-share/src/types/share.ts
+++ b/packages/linkedin-share/src/types/share.ts
@@ -41,18 +41,21 @@ export interface LinkedInShareContent {
   };
 }
 
+/**
+ * We only get the 'id' from the response @subhakar @vishwajeet
+ */
 export interface LinkedInShareResponse {
   id: string;
-  activity: string;
-  created: {
-    actor: string;
-    time: number;
-  };
-  lastModified: {
-    actor: string;
-    time: number;
-  };
-  lifecycleState: string;
+  // activity: string;
+  // created: {
+  //   actor: string;
+  //   time: number;
+  // };
+  // lastModified: {
+  //   actor: string;
+  //   time: number;
+  // };
+  // lifecycleState: string;
 }
 
 export interface LinkedInError {

--- a/packages/linkedin-share/src/types/share.ts
+++ b/packages/linkedin-share/src/types/share.ts
@@ -42,7 +42,7 @@ export interface LinkedInShareContent {
 }
 
 export interface LinkedInShareResponse {
-  sub: string;
+  id: string;
   activity: string;
   created: {
     actor: string;


### PR DESCRIPTION
After successfully sharing a post, the LinkedIn API returns only an `id` in the response. @VISHWAJ33T @karcreativeworks 

<img width="497" alt="Screenshot 2025-04-30 at 4 02 04 PM" src="https://github.com/user-attachments/assets/995cd0cc-06dd-4b00-bbf5-36a992768a61" />


Response from LinkedIn 👇

<img width="837" alt="Screenshot 2025-04-30 at 4 03 16 PM" src="https://github.com/user-attachments/assets/d607d2ee-afd2-4d5b-a9a3-0da8922ed09e" />
