### PR TITLE
feat(brave): add batch processing examples for web, image, video, and news search

### DIFF
--- a/packages/brave/README.md
+++ b/packages/brave/README.md
@@ -28,7 +28,7 @@ const braveSDK = createBraveSDK({
 const braveSDK = createBraveSDK(); // Uses BRAVE_API_KEY from environment
 ```
 
-## Rate Limits ( DO NOT USE PROMISE.A;l )
+## Rate Limits ( DO NOT USE PROMISE.All )
 
 - Free Plan: 1 request per second
 - Pro Plan: 20 requests per second
@@ -43,11 +43,10 @@ const results = await Promise.all([
 ]);
 
 // ✅ Do this instead
-const results = [];
-for (const query of ['query1', 'query2']) {
-  results.push(await braveSDK.webSearch({ q: query }));
-  await new Promise(resolve => setTimeout(resolve, 1000)); // 1 second delay
-}
+const results = await braveSdk.batchWebSearch([
+  { q: 'query1' },
+  { q: 'query2' },
+]);
 ```
 
 ## API Reference

--- a/packages/brave/docs/imageSearch.md
+++ b/packages/brave/docs/imageSearch.md
@@ -141,6 +141,33 @@ const processResults = async () => {
     console.error('Error performing image search:', error);
   }
 };
+
+// Batch image search example
+const batchImageSearchExample = async () => {
+  try {
+    // Define multiple image search queries
+    const searchQueries = [
+      { q: 'cats', count: 5, safesearch: 'moderate' },
+      { q: 'dogs', count: 5, safesearch: 'moderate' },
+      { q: 'birds', count: 5, safesearch: 'moderate' },
+    ];
+
+    // Process batch search with progress tracking
+    const results = await braveSDK.batchImageSearch(searchQueries);
+
+    // Process results for each query
+    results.forEach((response, index) => {
+      console.log(`\nResults for query "${searchQueries[index].q}":`);
+      const images = response.mixed.main;
+
+      images.forEach(image => {
+        console.log(`- ${image.title} (${image.source})`);
+      });
+    });
+  } catch (error) {
+    console.error('Error performing batch image search:', error);
+  }
+};
 ```
 
 ## Notes

--- a/packages/brave/docs/newsSearch.md
+++ b/packages/brave/docs/newsSearch.md
@@ -124,4 +124,35 @@ const articlesBySource = results.results.reduce(
   },
   {} as Record<string, typeof results.results>,
 );
+
+// Example: Batch news search
+const batchResults = await braveSDK.batchNewsSearch(
+  [
+    { q: 'technology news', freshness: 'pd' },
+    { q: 'sports news', country: 'US', count: 10 },
+    { q: 'business news', freshness: 'pw' },
+  ],
+  {
+    delay: 1000, // 1 second delay between requests
+    onProgress: (completed, total) => {
+      console.log(`Completed ${completed} of ${total} requests`);
+    },
+  },
+);
+
+// Process batch results
+batchResults.forEach((result, index) => {
+  if ('error' in result) {
+    console.error(`Error in request ${index + 1}:`, result.error);
+    return;
+  }
+
+  console.log(`\nResults for search ${index + 1}:`);
+  result.results.forEach((article, articleIndex) => {
+    console.log(`\nArticle ${articleIndex + 1}:`);
+    console.log('Title:', article.title);
+    console.log('Source:', article.meta_url?.source);
+    console.log('Age:', article.age);
+  });
+});
 ```

--- a/packages/brave/docs/videoSearch.md
+++ b/packages/brave/docs/videoSearch.md
@@ -143,4 +143,38 @@ const videosByCreator = results.results.reduce(
   },
   {} as Record<string, typeof results.results>,
 );
+
+// Example: Batch video search
+const batchResults = await braveSDK.batchVideoSearch(
+  [
+    { q: 'cute puppies', count: 5 },
+    { q: 'funny cats', count: 5 },
+    { q: 'baby animals', count: 5 },
+  ],
+  {
+    delay: 1000, // 1 second delay between requests
+    onProgress: (completed, total) => {
+      console.log(`Completed ${completed} of ${total} searches`);
+    },
+  },
+);
+
+// Process batch results
+batchResults.forEach((result, index) => {
+  if ('error' in result) {
+    console.error(`Search ${index + 1} failed:`, result.error);
+    return;
+  }
+
+  console.log(`\nResults for search ${index + 1}:`);
+  result.results.forEach((video, videoIndex) => {
+    console.log(`\nVideo ${videoIndex + 1}:`);
+    console.log('Title:', video.title);
+    console.log('URL:', video.url);
+    if (video.video) {
+      console.log('Duration:', video.video.duration);
+      console.log('Views:', video.video.views);
+    }
+  });
+});
 ```

--- a/packages/brave/docs/webSearch.md
+++ b/packages/brave/docs/webSearch.md
@@ -92,4 +92,33 @@ if (results.type === 'web') {
     console.log('FAQ Results:', results.faq.results);
   }
 }
+
+// Batch web search example
+const batchResults = await braveSDK.batchWebSearch([
+  { q: 'TypeScript' },
+  { q: 'JavaScript', count: 10 },
+  { q: 'Python', freshness: 'pw' },
+]);
+
+// Process batch results
+batchResults.forEach((result, index) => {
+  if (result.type === 'web' && result.search) {
+    console.log(`Batch ${index + 1} Results:`);
+    result.search.results.forEach((searchResult, resultIndex) => {
+      console.log(`  Result ${resultIndex + 1}:`, searchResult.title);
+      console.log('  URL:', searchResult.url);
+    });
+  }
+});
+
+// Batch search with progress tracking
+const batchResultsWithProgress = await braveSDK.batchWebSearch(
+  [{ q: 'React' }, { q: 'Vue' }, { q: 'Angular' }],
+  {
+    delay: 2000, // 2 second delay between requests
+    onProgress: (completed, total) => {
+      console.log(`Completed ${completed} of ${total} searches`);
+    },
+  },
+);
 ```


### PR DESCRIPTION
Reason:

the issue is brave search has a rate limit of 1 request per second in free plan, batch processing externally will hit the concurrent limit. so designed a inbuilt batcher which does sequential processing with the necessary delay.

Todos:
Optimise based on the users plan (which can be understood by response headers).