### PR TITLE
feat: add template type configuration for email services and update u…

### DIFF
--- a/packages/ai-provider-openai/package-info.json
+++ b/packages/ai-provider-openai/package-info.json
@@ -33,6 +33,19 @@
         }
       ],
       "internalKeys": [],
+      "botConfig": [
+        {
+          "key": "OPENAI_SECRET_TEMPLATE_TYPE",
+          "displayName": "Template Type",
+          "description": "The type of template to use for the email.",
+          "required": false,
+          "ui": {
+            "type": "text",
+            "label": "Template Type",
+            "placeholder": "markup"
+          }
+        }
+      ],
       "functionalities": []
     }
   ],

--- a/packages/ai-provider-openai/src/openAiProvider.ts
+++ b/packages/ai-provider-openai/src/openAiProvider.ts
@@ -83,7 +83,10 @@ export class OpenAiProvider {
       },
       async wrapGenerate({ doGenerate, params }) {
         const result = await doGenerate();
-        if (result.response?.modelId) {
+        if (
+          result.response?.modelId &&
+          process.env.OPENAI_SECRET_TEMPLATE_TYPE === 'markup'
+        ) {
           const tracker = createDefaultMicrofoxUsageTracker();
           tracker?.trackLLMUsage(
             'ai-provider-openai',

--- a/packages/aws-ses/package-info.json
+++ b/packages/aws-ses/package-info.json
@@ -72,6 +72,17 @@
             "label": "Sender Mail Domain Name",
             "placeholder": "reply-bots.com"
           }
+        },
+        {
+          "key": "AWS_SES_SECRET_TEMPLATE_TYPE",
+          "displayName": "Template Type",
+          "description": "The type of template to use for the email.",
+          "required": false,
+          "ui": {
+            "type": "text",
+            "label": "Template Type",
+            "placeholder": "markup"
+          }
         }
       ],
       "internalKeys": [],

--- a/packages/aws-ses/src/aws-ses-sdk.ts
+++ b/packages/aws-ses/src/aws-ses-sdk.ts
@@ -394,10 +394,12 @@ export const createSESSdk = (config: SESConfig): SESSDK => {
         })
         .json();
 
-      const tracker = createDefaultMicrofoxUsageTracker();
-      tracker?.trackApi1Usage('aws-ses', 'outboundEmail', {
-        requestCount: 1,
-      });
+      if (process.env.AWS_SES_SECRET_TEMPLATE_TYPE === 'markup') {
+        const tracker = createDefaultMicrofoxUsageTracker();
+        tracker?.trackApi1Usage('aws-ses', 'outboundEmail', {
+          requestCount: 1,
+        });
+      }
 
       return SendEmailResponseSchema.parse(response);
     } catch (error) {

--- a/packages/brave/package-info.json
+++ b/packages/brave/package-info.json
@@ -122,6 +122,19 @@
         }
       ],
       "internalKeys": [],
+      "botConfig": [
+        {
+          "key": "BRAVE_SECRET_TEMPLATE_TYPE",
+          "displayName": "Template Type",
+          "description": "The type of template to use for the email.",
+          "required": false,
+          "ui": {
+            "type": "text",
+            "label": "Template Type",
+            "placeholder": "markup"
+          }
+        }
+      ],
       "functionalities": [
         "request",
         "webSearch",

--- a/packages/brave/src/BraveSdk.ts
+++ b/packages/brave/src/BraveSdk.ts
@@ -158,10 +158,12 @@ class BraveSDK {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
 
-    const tracker = createDefaultMicrofoxUsageTracker();
-    tracker?.trackApi1Usage('brave', 'dataForSearch', {
-      requestCount: 1,
-    });
+    if (process.env.BRAVE_SEARCH_SECRET_TEMPLATE_TYPE === 'markup') {
+      const tracker = createDefaultMicrofoxUsageTracker();
+      tracker?.trackApi1Usage('brave', 'dataForSearch', {
+        requestCount: 1,
+      });
+    }
 
     return response.json() as Promise<T>;
   }


### PR DESCRIPTION
…sage tracking

- Introduced 'Template Type' configuration for OpenAI, AWS SES, and Brave packages to specify the type of template used for emails.
- Updated usage tracking logic to conditionally track API usage based on the 'Template Type' environment variable for each service.