### PR TITLE
chore: update Brave SDK status and refine Slack OAuth parameters

### DIFF
--- a/packages/brave/package-info.json
+++ b/packages/brave/package-info.json
@@ -4,7 +4,7 @@
   "description": "The Brave SDK for TypeScript provides convenient access to various Brave APIs, including web, image, video, news, and local search functionalities, as well as summarization, spell check, and suggestions.",
   "path": "packages/brave",
   "dependencies": [],
-  "status": "semiStable",
+  "status": "stable",
   "authEndpoint": "",
   "oauth2Scopes": [],
   "documentation": "https://www.npmjs.com/package/@microfox/brave",

--- a/packages/slack-oauth/src/slackOAuthSdk.ts
+++ b/packages/slack-oauth/src/slackOAuthSdk.ts
@@ -36,6 +36,8 @@ export class SlackOAuthSdk {
     this.isGovSlack = validatedConfig.isGovSlack || false;
   }
 
+  //not-added  = single_channel=0&install_redirect=&tracked=1&team=
+
   /**
    * Generates the authorization URL for Slack OAuth
    * @param state Optional state parameter to maintain state across the redirect
@@ -49,12 +51,10 @@ export class SlackOAuthSdk {
     const params = new URLSearchParams({
       client_id: this.clientId,
       scope: this.scopes.join(','),
+      user_scope: this.userScopes?.join(',') ?? '',
       redirect_uri: this.redirectUri,
+      granular_bot_scope: '1',
     });
-
-    if (this.userScopes && this.userScopes.length > 0) {
-      params.append('user_scope', this.userScopes.join(','));
-    }
 
     if (this.team) {
       params.append('team', this.team);


### PR DESCRIPTION
- Changed the status of the Brave SDK in package-info.json from `semiStable` to `stable` to reflect its readiness for production use.
- Simplified the Slack OAuth SDK by removing conditional logic for user scopes and ensuring the `user_scope` parameter is always included in the authorization URL generation.