### PR TITLE
refactor: Tool Security Schema

### DIFF
--- a/packages/tool-kit/src/client/OpenAPiMcp.ts
+++ b/packages/tool-kit/src/client/OpenAPiMcp.ts
@@ -945,7 +945,7 @@ export class OpenApiMCP {
         let finalAuth: AuthObject | undefined;
 
         // Replace the auth config extraction with getAuthOptions
-        const { packages, customSecrets } = getAuthOptions(this.schema);
+        const { packages, customSecrets } = getAuthOptions(this.schema, cleanedOperation);
 
         if (!finalAuth) {
           if (toolGetAuth) {

--- a/packages/tool-kit/src/types.ts
+++ b/packages/tool-kit/src/types.ts
@@ -4,9 +4,8 @@ import {
   AgentOpenApi,
   AgentUi,
   JsonSchema,
-  MicrofoxHitlDetails,
+  HitlDetails,
   SecurityRequirementObject,
-  MicrofoxPackageAuthDetails,
 } from '@microfox/types';
 import { z } from 'zod';
 
@@ -82,7 +81,7 @@ export type OpenAPIOperation = {
   tags?: string[];
   ai?: AgentPathAiInstruction;
   security?: SecurityRequirementObject[];
-  'x-microfox-hitl'?: MicrofoxHitlDetails;
+  hitl?: HitlDetails;
   ui?: AgentUi;
   parameters?: OpenAPIParameter[];
   requestBody?: OpenAPIRequestBody;
@@ -160,7 +159,15 @@ export type AuthOptions = {
     packageName: string;
     packageConstructor?: string[];
   }[];
-  customSecrets?: MicrofoxPackageAuthDetails['customSecrets'];
+  customSecrets?:{
+    key: string;
+    description: string;
+    required: boolean;
+    type: string;
+    format?: string;
+    enum?: any[];
+    default?: any;
+  }[];
 };
 
 export type AuthObject = {

--- a/packages/types/src/agent.types.ts
+++ b/packages/types/src/agent.types.ts
@@ -7,21 +7,6 @@ export interface AgentServers {
   description: string;
 }
 
-export interface MicrofoxPackageAuthDetails {
-  type?: '@microfox/packages';
-  packageName?: string;
-  packageConstructor?: string[];
-  customSecrets?: {
-    key: string;
-    description: string;
-    required: boolean;
-    type: string;
-    format?: string;
-    enum?: any[];
-    default?: any;
-  }[];
-}
-
 export interface AgentInfo {
   agentName: string;
   agentPath: `@microagent/${string}` | `@microfox/${string}`;
@@ -33,7 +18,6 @@ export interface AgentInfo {
   iconUrl?: string;
   status?: 'stable' | 'semi-stable' | 'beta' | 'experimental';
   agentCard?: AgentCard;
-  packageAuthDetails?: MicrofoxPackageAuthDetails[];
   contact?: {
     name: string;
     email: string;
@@ -49,7 +33,7 @@ export interface AgentPathAiInstruction {
   preferredModel?: string;
 }
 
-export interface MicrofoxHitlDetails {
+export interface HitlDetails {
   requiresHITL?: boolean;
   hitlPrompt?: string;
   hitlPriority?: number;
@@ -74,7 +58,7 @@ export interface AgentPath {
     description: string;
     tags: string[];
     ai?: AgentPathAiInstruction;
-    'x-microfox-hitl'?: MicrofoxHitlDetails;
+    hitl?: HitlDetails;
     security?: SecurityRequirementObject[];
     ui?: AgentUi;
     parameters?: {


### PR DESCRIPTION
Standard Openapi security
```{
  "components": {
    "securitySchemes": {
      "APIKeyAuth": {
        "type": "apiKey",
        "name": "X-API-Key",
        "in": "header"
      },
      "OAuth2": {
        "type": "oauth2",
        "flows": {
          "implicit": {
            "authorizationUrl": "https://example.com/oauth/authorize",
            "scopes": {
              "read:pets": "read your pets",
              "write:pets": "modify pets in your account"
            }
          }
        }
      }
    }
  },
  "security": [
    {
      "APIKeyAuth": []
    },
    {
      "OAuth2": [
        "read:pets"
      ]
    }
  ]
}
```
Our Plan
```
  security: [
    {
      "x-microfox-packages": ["@microfox/ai-provider-anthropic"],
      "stocksearchAuth": []
    },
  ],
  components: {
    securitySchemes: {
      "stocksearchAuth": {
        "type": "apiKey",
        "in": "header",
        "name": "STOCKSEARCH_API_KEY_HEADER",
        "description": "Encrypted authentication secrets for Microfox services."
      },
    }
```
@karcreativeworks there is no use of "in": "header" right? also will there be need of package constructors(they were there in our previous setup)?

security is an ARRAY not object, can we use that somehow?